### PR TITLE
step_delay must be in microseconds

### DIFF
--- a/firmware/Stepper.cpp
+++ b/firmware/Stepper.cpp
@@ -188,7 +188,7 @@ void Stepper::setSpeed(long whatSpeed)
   if (whatSpeed == 0)
     whatSpeed = 1;
 
-  this->step_delay = 60L * 1000L / this->number_of_steps / whatSpeed;
+  this->step_delay = 60L * 1000L * 1000L / this->number_of_steps / whatSpeed;
 }
 
 /*


### PR DESCRIPTION
Since we're comparing against micros() to determine when to next send a step signal to the motor, we need to multiply by a factor of 1000^2 to get a delay in microseconds.  Without this change, a stepper motor will simply vibrate.